### PR TITLE
Add label on 'No Topbar' layout

### DIFF
--- a/resources/views/livewire/ui-switcher.blade.php
+++ b/resources/views/livewire/ui-switcher.blade.php
@@ -17,17 +17,22 @@
         window.dispatchEvent(new CustomEvent('theme-changed', { detail: 'system' }));
      ">
 
-    {{-- Cog icon in topbar --}}
+    {{-- Cog icon in topbar/sidebar --}}
     <button
         wire:click="toggle"
-        class="flex items-center justify-center w-9 h-9 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        class="flex items-center gap-2 {{ $layout === 'sidebar-no-topbar' ? 'justify-start w-full px-3 py-2' : 'justify-center w-9 h-9' }} rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
         type="button"
         aria-label="{{ __('filament-ui-switcher::filament-ui-switcher.button.aria_label') }}"
     >
         <x-filament::icon
             icon="{{ $this->icon }}"
-            class="h-5 w-5"
+            class="h-5 w-5 {{ $layout === 'sidebar-no-topbar' ? 'shrink-0' : '' }}"
         />
+        @if($layout === 'sidebar-no-topbar')
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('filament-ui-switcher::filament-ui-switcher.modal.heading') }}
+            </span>
+        @endif
     </button>
 
     {{-- Slideover Modal --}}


### PR DESCRIPTION
Show the label next to the icon when the user picks the "No Topbar" version.

Fix https://github.com/andreia/filament-ui-switcher/issues/4