### PR TITLE
register ApplyUiPreferences as authMiddleware to ensure session is available

### DIFF
--- a/src/FilamentUiSwitcherPlugin.php
+++ b/src/FilamentUiSwitcherPlugin.php
@@ -40,7 +40,7 @@ class FilamentUiSwitcherPlugin implements Plugin
     public function register(Panel $panel): void
     {
         // Register custom middleware to apply preferences after session is available
-        $panel->middleware([
+        $panel->authMiddleware([
             \Andreia\FilamentUiSwitcher\Http\Middleware\ApplyUiPreferences::class,
         ], isPersistent: true);
 


### PR DESCRIPTION
## Problem
ApplyUiPreferences middleware was registered via panel->middleware() inside 
register(), which runs before StartSession middleware. This means the session 
is not available, so preferences cannot be read and nothing gets applied.

## Fix
Register as authMiddleware() instead, which runs after the session and auth 
are fully bootstrapped — making session preferences accessible.

Fixes: color, layout, and font switching not being applied (only font size worked).